### PR TITLE
QuickWiki popup functionality added

### DIFF
--- a/style.css
+++ b/style.css
@@ -93,3 +93,39 @@
     background-color: #e4e4fa;
     padding: 2px 0px;
 }
+
+.wiki-popup {
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    z-index: 999;
+    
+    width: 400px;
+    border: 1px solid #ccc;
+    box-shadow: 0px 0px 20px #bbb;
+    -webkit-box-shadow: 0px 0px 20px #bbb;
+    background-color: white;
+}
+
+.wiki-popup-body {
+   font-size: 0.875em;
+   padding: 0.5em;
+}
+
+.wiki-popup-footer {
+    font-size: 0.875em;
+    text-align: right;
+}
+
+.imageWrap {
+    float: right;
+    width: 30%;
+    height: auto;
+}
+
+.imageWrap > img {
+    float: right;
+    height: 100%;
+    width: 100%;
+    display: block;
+}


### PR DESCRIPTION
Referencing issue #10 

Changes : 
* Preview popup modal on mouse hover over links
* Popup modals can be fired even on the links within the popup
* Preview popup modal also fired in QuickWiki modal link on hover
* Image support in the hover popup
* Cache support for faster popup rendering

Caveat : 
* No initial support for Wikia.com as underlying structures differ, will be investigated later on. So added a check before binding popups
